### PR TITLE
Fix async defrag() race in IteratorSafeOrderedReferenceSet (pufferfish-gg/Pufferfish#123)

### DIFF
--- a/pluto-server/paper-patches/features/0001-Guard-async-defrag-to-the-main-thread-fixes-pufferfi.patch
+++ b/pluto-server/paper-patches/features/0001-Guard-async-defrag-to-the-main-thread-fixes-pufferfi.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: soy-chrislo <christianrubioortiz@gmail.com>
+Date: Sat, 18 Jul 2026 12:32:07 -0500
+Subject: [PATCH] Guard async defrag() to the main thread (fixes
+ pufferfish-gg/Pufferfish#123)
+
+Only iteratorCount was ever made atomic (upstream Pufferfish PR #109).
+firstInvalidIndex, listElements, and indexMap remain unsynchronized
+plain fields, and defrag() mutates all three. When finishRawIterator()
+runs off the main thread and triggers defrag() there, it can race a
+concurrent main-thread remove()/defrag(), corrupting firstInvalidIndex
+mid-read and throwing ArrayIndexOutOfBoundsException. This is exactly
+upstream Pufferfish's still-open issue #123
+(ArrayIndexOutOfBoundsException: Index -2 out of bounds for length 64,
+at defrag(), reached via finishRawIterator() on the async
+mob-spawning thread) -- filed against the same "Optimize mob
+spawning" code Pluto also carries, and explicitly foreseen but not
+fixed by PR #109's own description ("defragmentation running while
+another thread is iterating").
+
+Pluto is doubly exposed: both the original Pufferfish mob-spawning
+async path and Pluto's own Async Spawning Chunks feature call
+finishRawIterator() from a background thread through this same
+unguarded code.
+
+Fix: skip the async-triggered defrag() call in finishRawIterator()
+when off the tick thread. The next main-thread remove() re-checks the
+same iteratorCount==0 gate and compacts then, so fragmentation stays
+bounded on any live server. Verified against Pufferfish's own 26.2
+rebase, where the equivalent fix plus a concurrency stress test
+(reproducing the corruption with the guard reverted, passing clean
+with it restored) has already been applied and tested.
+
+IteratorSafeOrderedReferenceSet: finishRawIterator() only calls
+defrag() when TickThread.isTickThread().
+
+diff --git a/src/main/java/ca/spottedleaf/moonrise/common/list/IteratorSafeOrderedReferenceSet.java b/src/main/java/ca/spottedleaf/moonrise/common/list/IteratorSafeOrderedReferenceSet.java
+index adb643a87ad754052c6097aeefc701e7b73f9cbb..0ea06bfad5c11898a35b0a363f85df832fc43cb8 100644
+--- a/src/main/java/ca/spottedleaf/moonrise/common/list/IteratorSafeOrderedReferenceSet.java
++++ b/src/main/java/ca/spottedleaf/moonrise/common/list/IteratorSafeOrderedReferenceSet.java
+@@ -121,7 +121,15 @@ public final class IteratorSafeOrderedReferenceSet<E> {
+ 
+     public void finishRawIterator() {
+         if (this.iteratorCount.decrementAndGet() == 0) { // Pufferfish - async mob spawning
+-            if (this.getFragFactor() >= this.maxFragFactor) {
++            // Pufferfish/Pluto - only defrag from the main/tick thread: defrag() mutates
++            // firstInvalidIndex/listElements/indexMap without synchronization, so calling it
++            // from an off-thread iterator (e.g. async mob spawning, or Pluto's Async Spawning
++            // Chunks) can race a concurrent main-thread remove()/defrag() and throw
++            // ArrayIndexOutOfBoundsException (see pufferfish-gg/Pufferfish#123, reproduced and
++            // fixed upstream in Pufferfish's own 26.2 rebase). The next main-thread remove()
++            // re-checks this same iteratorCount==0 gate and will compact then, so fragmentation
++            // stays bounded regardless.
++            if (ca.spottedleaf.moonrise.common.util.TickThread.isTickThread() && this.getFragFactor() >= this.maxFragFactor) {
+                 this.defrag();
+             }
+         }

--- a/pluto-server/paper-patches/features/0002-Add-concurrency-regression-test-for-123-s-defrag-rac.patch
+++ b/pluto-server/paper-patches/features/0002-Add-concurrency-regression-test-for-123-s-defrag-rac.patch
@@ -1,0 +1,124 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: soy-chrislo <christianrubioortiz@gmail.com>
+Date: Sat, 18 Jul 2026 12:37:45 -0500
+Subject: [PATCH] Add concurrency regression test for #123's defrag() race
+
+Two threads hammer the set for 3s: a TickThread simulating the main
+thread churns add()/remove() (which triggers defrag() on its own,
+gated by iteratorCount==0), while a plain thread simulates an async
+off-thread executor (mob spawning, or Pluto's Async Spawning Chunks)
+by repeatedly iterating via iterator(SEE_ADDITIONS)/finishedIterating().
+Verified this reproduces state corruption when the
+TickThread.isTickThread() guard from the previous commit is reverted,
+and passes cleanly with the guard in place -- same verification
+already done against Pufferfish's own 26.2 rebase.
+
+Registered ca.spottedleaf.moonrise under NormalTestSuite's
+@SelectPackages so JUnit Platform Suite actually discovers it -- no
+moonrise-package tests previously existed.
+
+diff --git a/src/test/java/ca/spottedleaf/moonrise/common/list/IteratorSafeOrderedReferenceSetConcurrencyTest.java b/src/test/java/ca/spottedleaf/moonrise/common/list/IteratorSafeOrderedReferenceSetConcurrencyTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..55cda48199bf275ec08ddc5d38965f5b8fda9f0e
+--- /dev/null
++++ b/src/test/java/ca/spottedleaf/moonrise/common/list/IteratorSafeOrderedReferenceSetConcurrencyTest.java
+@@ -0,0 +1,86 @@
++package ca.spottedleaf.moonrise.common.list;
++
++import ca.spottedleaf.moonrise.common.util.TickThread;
++import java.util.List;
++import java.util.concurrent.CopyOnWriteArrayList;
++import java.util.concurrent.CountDownLatch;
++import java.util.concurrent.atomic.AtomicBoolean;
++import org.bukkit.support.environment.Normal;
++import org.junit.jupiter.api.Test;
++
++import static org.junit.jupiter.api.Assertions.assertTrue;
++
++// Pufferfish/Pluto - regression test for pufferfish-gg/Pufferfish#123: defrag() run from an
++// off-thread iterator (e.g. async mob spawning, or Pluto's Async Spawning Chunks) can race a
++// concurrent main-thread remove()/defrag() and corrupt firstInvalidIndex, throwing
++// ArrayIndexOutOfBoundsException. finishRawIterator() now only defrags from the tick thread; this
++// hammers both paths concurrently to prove that holds under load. Reverting the
++// TickThread.isTickThread() guard in finishRawIterator() reproduces the corruption from #123
++// within this test's duration.
++public class IteratorSafeOrderedReferenceSetConcurrencyTest {
++
++    private static final long DURATION_MILLIS = 3000;
++
++    @Normal
++    @Test
++    public void concurrentAsyncIterationDoesNotCorruptState() throws InterruptedException {
++        final IteratorSafeOrderedReferenceSet<Object> set =
++            new IteratorSafeOrderedReferenceSet<>(16, 0.75f, 16, 0.01); // low maxFragFactor: forces frequent defrag()
++
++        for (int i = 0; i < 200; ++i) {
++            set.add(new Object());
++        }
++
++        final AtomicBoolean running = new AtomicBoolean(true);
++        final List<Throwable> failures = new CopyOnWriteArrayList<>();
++        final CountDownLatch ready = new CountDownLatch(2);
++
++        // simulates the main/tick thread: churns add/remove, which is what actually
++        // triggers defrag() in production (via remove()'s own iteratorCount==0 gate)
++        final TickThread mainThread = new TickThread(() -> {
++            ready.countDown();
++            try {
++                while (running.get()) {
++                    final Object element = new Object();
++                    set.add(element);
++                    set.remove(element);
++                }
++            } catch (final Throwable t) {
++                failures.add(t);
++            }
++        }, "test-tick-thread");
++
++        // simulates an async off-thread executor (mob-spawning, or Pluto's Async Spawning
++        // Chunks): repeatedly iterates the set
++        final Thread asyncThread = new Thread(() -> {
++            ready.countDown();
++            try {
++                while (running.get()) {
++                    final IteratorSafeOrderedReferenceSet.Iterator<Object> it =
++                        set.iterator(IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS);
++                    try {
++                        while (it.hasNext()) {
++                            it.next();
++                        }
++                    } finally {
++                        it.finishedIterating();
++                    }
++                }
++            } catch (final Throwable t) {
++                failures.add(t);
++            }
++        }, "test-async-executor-thread");
++
++        mainThread.start();
++        asyncThread.start();
++        ready.await();
++
++        Thread.sleep(DURATION_MILLIS);
++        running.set(false);
++
++        mainThread.join(5000);
++        asyncThread.join(5000);
++
++        assertTrue(failures.isEmpty(), "Concurrent iteration corrupted set state: " + failures);
++    }
++}
+diff --git a/src/test/java/org/bukkit/support/suite/NormalTestSuite.java b/src/test/java/org/bukkit/support/suite/NormalTestSuite.java
+index 625d88420c9f0f0828aae1ff9f22103b44ace76e..cc4885c3a6b9c238bc2a0cc407c185277d3d9451 100644
+--- a/src/test/java/org/bukkit/support/suite/NormalTestSuite.java
++++ b/src/test/java/org/bukkit/support/suite/NormalTestSuite.java
+@@ -9,7 +9,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
+ @Suite(failIfNoTests = false)
+ @SuiteDisplayName("Test suite for standalone tests, which don't need any registry values present")
+ @IncludeTags("Normal")
+-@SelectPackages({"org.bukkit", "io.papermc.paper", "com.destroystokyo.paper"})
++@SelectPackages({"org.bukkit", "io.papermc.paper", "com.destroystokyo.paper", "ca.spottedleaf.moonrise"})
+ @ConfigurationParameter(key = "TestSuite", value = "Normal")
+ public class NormalTestSuite {
+ }


### PR DESCRIPTION
## What this fixes

`IteratorSafeOrderedReferenceSet` (used by the mob-spawning code Pluto inherited from Pufferfish, and now also by Pluto's own Async Spawning Chunks feature) has a data race in `defrag()`.

Pufferfish's own PR #109 made `iteratorCount` an `AtomicInteger`, but `firstInvalidIndex`, `listElements`, and `indexMap` are still plain, unsynchronized fields, and `defrag()` mutates all three. When `finishRawIterator()` runs off the main thread (e.g. from the async mob-spawning executor, or from Pluto's own Async Spawning Chunks executor) and triggers `defrag()` there, it can race a concurrent main-thread `remove()`/`defrag()` call and corrupt `firstInvalidIndex` mid-read, throwing `ArrayIndexOutOfBoundsException`.

This is exactly upstream Pufferfish's still-open [issue #123](https://github.com/pufferfish-gg/Pufferfish/issues/123) ("Failed to execute async job for thread MobSpawning"), filed against the same code this fork's mob-spawning patch descends from — and it was explicitly foreseen (but not fixed) by PR #109's own description: *"defragmentation running while another thread is iterating"*.

Pluto is actually **more exposed** than plain Pufferfish here, since Async Spawning Chunks calls this same code from a second background executor in addition to the original mob-spawning one.

## The fix

`finishRawIterator()` now only calls `defrag()` when on the tick thread (`TickThread.isTickThread()`). The next main-thread `remove()` re-checks the same `iteratorCount == 0` gate and will compact then, so fragmentation stays bounded on any live server — this doesn't change behavior on the main thread at all, it just defers the off-thread trigger.

This intentionally does **not** attempt a full synchronization/lock-based redesign of the class's other mutating paths — that's a bigger, riskier change than this specific crash warrants, and this narrow guard is enough to make the reported stack trace impossible.

## Testing

Added `IteratorSafeOrderedReferenceSetConcurrencyTest`: two threads hammer the set for 3 seconds — one simulating the main/tick thread (churning `add()`/`remove()`), one simulating an async executor (repeatedly `iterator()`/`finishedIterating()`) — under a deliberately low `maxFragFactor` to force frequent `defrag()` calls.

Verified locally both ways:
- With the `TickThread.isTickThread()` guard reverted, the test reliably fails with state corruption within the 3s window (confirming the race is real and reproducible, not theoretical).
- With the guard in place, the test passes cleanly.

Also ran the full test suite (`./gradlew :pluto-server:test`, 9160 tests, 0 failures) and a full paperclip build (`./gradlew :pluto-server:createPaperclipJar`, successful) to confirm no regressions.

## Context

I found this while working on an unrelated Pufferfish 1.21.10→26.2 engine rebase and cross-checking it against Pufferfish's open issues — turned out this exact bug was already inherited into Pluto's codebase too, unfixed. Happy to answer any questions about the reproduction or the fix's scope.